### PR TITLE
fix: generate cmd shims

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 !/.yarn/releases
 /dist
 /package.tgz
+
+/shims

--- a/mkshims.ts
+++ b/mkshims.ts
@@ -30,7 +30,7 @@ async function main() {
       fs.writeFileSync(entryPath, entryScript);
       fs.chmodSync(entryPath, 0o755);
 
-      await cmdShim(entryPath, `${__dirname}/shims/${binaryName}`, {});
+      await cmdShim(entryPath, `${__dirname}/shims/${binaryName}`, {createCmdFile: true});
     }
   }
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

There are no cmd shims for Windows since `@zkochan/cmd-shim` only makes those, unless explicitly enabled, when running on Windows.

**How did you fix it?**

Explicitly enable creating cmd shims