### PR TITLE
build: don't try to use yarn before building it

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,7 @@ jobs:
 
     - name: 'Build Node with corepack master'
       run: |
+        yarn install --immutable
         yarn pack
         git clone -b mael/pmm --depth=1 https://github.com/arcanis/node.git node && cd node
         git config user.name 'John Doe'

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -22,5 +22,6 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
 
+    - run: yarn install --immutable
     - run: yarn eslint
     - run: yarn jest

--- a/package.json
+++ b/package.json
@@ -42,9 +42,9 @@
     "webpack-cli": "^3.3.11"
   },
   "scripts": {
-    "build": "rm -rf dist && yarn webpack && yarn ts-node ./mkshims.ts",
+    "build": "rm -rf dist && webpack && ts-node ./mkshims.ts",
     "corepack": "ts-node ./sources/main.ts",
-    "prepack": "yarn build",
+    "prepack": "node ./.yarn/releases/*.*js build",
     "postpack": "rm -rf dist shims"
   },
   "files": [


### PR DESCRIPTION
**What's the problem this PR addresses?**

The build script is trying to use `yarn` to run `webpack` but because of the order the "binjumpers" are created in Yarn, that points to the local one which doesn't exist yet so it fails.

**How did you fix it?**

Use the binaries directly without calling Yarn