### PR TITLE
fix: avoid symlinks to work on Windows

### DIFF
--- a/sources/Engine.ts
+++ b/sources/Engine.ts
@@ -77,9 +77,14 @@ export class Engine {
     if (typeof range === `undefined`)
       throw new Error(`Assertion failed: Specified resolution (${locator.reference}) isn't supported by any of ${ranges.join(`, `)}`);
 
-    return await pmmUtils.installVersion(folderUtils.getInstallFolder(), locator, {
+    const installedLocation = await pmmUtils.installVersion(folderUtils.getInstallFolder(), locator, {
       spec: definition.ranges[range],
     });
+
+    return {
+      location: installedLocation,
+      spec: definition.ranges[range],
+    };
   }
 
   async resolveDescriptor(descriptor: Descriptor, {useCache = true}: {useCache?: boolean} = {}) {

--- a/sources/commands/Prepare.ts
+++ b/sources/commands/Prepare.ts
@@ -75,7 +75,7 @@ export class PrepareCommand extends Command<Context> {
         throw new UsageError(`Failed to successfully resolve '${spec.range}' to a valid ${spec.name} release`);
 
       const baseInstallFolder = folderUtils.getInstallFolder();
-      const installFolder = await this.context.engine.ensurePackageManager(resolved);
+      const installSpec = await this.context.engine.ensurePackageManager(resolved);
 
       if (this.activate)
         await this.context.engine.activatePackageManager(resolved);
@@ -87,7 +87,7 @@ export class PrepareCommand extends Command<Context> {
         ? path.join(this.context.cwd, `corepack-${resolved.name}-${resolved.reference}.tgz`)
         : path.join(this.context.cwd, `corepack-${resolved.name}.tgz`);
 
-      await tar.c({gzip: true, cwd: baseInstallFolder, file: fileName}, [path.relative(baseInstallFolder, installFolder)]);
+      await tar.c({gzip: true, cwd: baseInstallFolder, file: fileName}, [path.relative(baseInstallFolder, installSpec.location)]);
 
       if (this.json) {
         this.context.stdout.write(`${JSON.stringify(fileName)}\n`);

--- a/sources/fsUtils.ts
+++ b/sources/fsUtils.ts
@@ -1,10 +1,3 @@
-import fs                  from 'fs';
-import {dirname, relative} from 'path';
-
 export async function mutex<T>(p: string, cb: () => Promise<T>) {
   return await cb();
-}
-
-export async function makeShim(target: string, path: string) {
-  await fs.promises.symlink(relative(dirname(target), path), target, `file`);
 }

--- a/sources/main.ts
+++ b/sources/main.ts
@@ -48,8 +48,8 @@ export async function main(argv: Array<string>, context: CustomContext & Partial
         if (resolved === null)
           throw new UsageError(`Failed to successfully resolve '${descriptor.range}' to a valid ${descriptor.name} release`);
 
-        const installTarget = await context.engine.ensurePackageManager(resolved);
-        const exitCode = await pmmUtils.runVersion(installTarget, resolved, binaryName, this.proxy, this.context);
+        const installSpec = await context.engine.ensurePackageManager(resolved);
+        const exitCode = await pmmUtils.runVersion(installSpec, resolved, binaryName, this.proxy, this.context);
 
         return exitCode;
       }


### PR DESCRIPTION
**What's the problem this PR addresses?**

The use of symlinks caused permission issues on Windows, and they aren't really necessary as we can just spawn the files directly

**How did you fix it?**

Avoid symlinks and just spawn the files directly