### PR TITLE
Fixes the corepack binary

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,7 +7,6 @@
   "eslint.nodePath": ".yarn/sdks",
   "typescript.enablePromptUseWorkspaceTsdk": true,
   "editor.codeActionsOnSave": {
-    "source.fixAll": true,
     "source.fixAll.eslint": true
   }
 }

--- a/mkshims.ts
+++ b/mkshims.ts
@@ -1,24 +1,14 @@
-import cmdShim                    from '@zkochan/cmd-shim';
-import fs                         from 'fs';
-import {SupportedPackageManagers} from 'sources/types';
+import cmdShim                      from '@zkochan/cmd-shim';
+import fs                           from 'fs';
 
-import config                     from './config.json';
+import {Engine}                     from './sources/Engine';
+import {SupportedPackageManagerSet} from './sources/types';
+
+const engine = new Engine();
 
 async function main() {
-  for (const packageManager of Object.keys(config.definitions) as Array<SupportedPackageManagers>) {
-    const binSet = new Set<string>();
-
-    for (const spec of Object.values(config.definitions[packageManager].ranges)) {
-      if (Array.isArray(spec.bin)) {
-        for (const entry of spec.bin) {
-          binSet.add(entry);
-        }
-      } else {
-        for (const entry of Object.keys(spec.bin)) {
-          binSet.add(entry);
-        }
-      }
-    }
+  for (const packageManager of SupportedPackageManagerSet) {
+    const binSet = engine.getBinariesFor(packageManager);
 
     for (const binaryName of binSet) {
       const entryPath = `${__dirname}/dist/${binaryName}.js`;

--- a/sources/main.ts
+++ b/sources/main.ts
@@ -95,8 +95,6 @@ export function runMain(argv: Array<string>) {
   });
 }
 
-declare const __non_webpack_require__: any;
-
-if (typeof __non_webpack_require__ === `undefined` && process.mainModule === module)
+// Using `eval` to be sure that Webpack doesn't transform it
+if (process.mainModule === eval(`module`))
   runMain(process.argv.slice(2));
-


### PR DESCRIPTION
The corepack binary wasn't properly detecting when it was being spawned by itself when installed via npm. This diff fixes that by removing the check used to ensure that the CLI only ran when invoked directly from within the repo, or indirectly by one of the shims.

Fixes #12 