### PR TITLE
Restricts to exact versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "yarn": "./dist/yarn.js",
     "yarnpkg": "./dist/yarnpkg.js"
   },
-  "packageManager": "yarn@^2.0.0-rc.29",
+  "packageManager": "yarn@2.0.0-rc.29",
   "devDependencies": {
     "@babel/core": "^7.11.0",
     "@babel/plugin-proposal-class-properties": "^7.10.4",

--- a/sources/specUtils.ts
+++ b/sources/specUtils.ts
@@ -12,8 +12,8 @@ export function parseSpec(raw: unknown, source?: string): Descriptor {
     throw new UsageError(`Invalid package manager specification in ${source}; expected a string`);
 
   const match = raw.match(/^(?!_)(.+)@(.+)$/);
-  if (match === null || !semver.validRange(match[2]))
-    throw new UsageError(`Invalid package manager specification in ${source}; expected a semver range`);
+  if (match === null || !semver.valid(match[2]))
+    throw new UsageError(`Invalid package manager specification in ${source}; expected a semver version`);
 
   if (!isSupportedPackageManager(match[1]))
     throw new UsageError(`Unsupported package manager specification (${match})`);
@@ -109,7 +109,7 @@ export async function loadSpec(initialCwd: string): Promise<LoadSpecResult> {
 }
 
 export async function persistPmSpec(updateTarget: string, locator: Locator, message: string) {
-  const newSpec = `${locator.name}@^${locator.reference}`;
+  const newSpec = `${locator.name}@${locator.reference}`;
 
   let res: boolean;
   try {


### PR DESCRIPTION
Ranges are a tad dangerous because there's no telling which version will be installed exactly. While they are supposed to be compatible, the pros and cons are somewhat unbalanced at the moment: the risk of a regression is higher than the potential size gain, because Corepack doesn't cover npm at the moment - which is the main case where deduplication would matter.

It's better to restrict the `packageManager` field to strict semver versions for this first iteration and see if there's a need for ranges (which would be possible to add in a minor) than do the opposite and have to make a backward-incompatible change later down the road.