### PR TITLE
Adds the missing corepack shim

### DIFF
--- a/mkshims.ts
+++ b/mkshims.ts
@@ -1,17 +1,21 @@
 import cmdShim                      from '@zkochan/cmd-shim';
 import fs                           from 'fs';
+import path                         from 'path';
 
 import {Engine}                     from './sources/Engine';
 import {SupportedPackageManagerSet} from './sources/types';
 
 const engine = new Engine();
 
+const distDir = path.join(__dirname, `dist`);
+const shimsDir = path.join(__dirname, `shims`);
+
 async function main() {
   for (const packageManager of SupportedPackageManagerSet) {
     const binSet = engine.getBinariesFor(packageManager);
 
     for (const binaryName of binSet) {
-      const entryPath = `${__dirname}/dist/${binaryName}.js`;
+      const entryPath = path.join(distDir, `${binaryName}.js`);
       const entryScript = [
         `#!/usr/bin/env node\n`,
         `require('./corepack').runMain(['${packageManager}', '${binaryName}', ...process.argv.slice(2)]);\n`,
@@ -19,10 +23,11 @@ async function main() {
 
       fs.writeFileSync(entryPath, entryScript);
       fs.chmodSync(entryPath, 0o755);
-
-      await cmdShim(entryPath, `${__dirname}/shims/${binaryName}`, {createCmdFile: true});
     }
   }
+
+  for (const binaryName of fs.readdirSync(distDir))
+    await cmdShim(path.join(distDir, binaryName), path.join(shimsDir, path.basename(binaryName, `.js`)), {createCmdFile: true});
 
   console.log(`All shims have been generated.`);
 }


### PR DESCRIPTION
The `corepack` shim didn't exist in the published archive (since `mkshim` was only iterating over the package manager binaries). This fixes that.