### PR TITLE
Prevents npm from being accidentally set

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,15 +69,31 @@ The Known Good Releases can be updated system-wide using the `--activate` flag f
 
 The utility commands detailed in the next section.
 
-- Either you can use the network while building your container image, in which case you'll simply run `corepack prepare --cache-only <name>` to make sure that your image includes the Last Known Good release for the specified package manager.
+- Either you can use the network while building your container image, in which case you'll simply run `corepack prepare` to make sure that your image includes the Last Known Good release for the specified package manager.
 
   - If you want to have *all* Last Known Good releases for all package managers, just use the `--all` flag which will do just that.
 
-- Or you're publishing your project to a system where the network is unavailable, in which case you'll preemptively generate a package manager archive from your local computer (using `corepack prepare`) before storing it somewhere your container will be able to access (for example within your repository). After that, it's just a matter of running `corepack hydrate <path/to/corepack>` to setup the cache.
+- Or you're publishing your project to a system where the network is unavailable, in which case you'll preemptively generate a package manager archive from your local computer (using `corepack prepare -o`) before storing it somewhere your container will be able to access (for example within your repository). After that it'll just be a matter of running `corepack hydrate <path/to/corepack.tgz>` to setup the cache.
 
 ## Utility Commands
 
-### `corepack prepare [name@version]`
+### `corepack enable [... name]`
+
+| Option | Description |
+| --- | --- |
+| `--install-directory` | Add the shims to the specified location |
+
+This command will detect where Node is installed and will create shims next to it for each of the specified package managers (or all of them if the command is called without parameters). Note that the npm shims will not be installed unless explicitly requested, as npm is currently distributed with Node through other means.
+
+### `corepack disable [... name]`
+
+| Option | Description |
+| --- | --- |
+| `--install-directory` | Remove the shims to the specified location |
+
+This command will detect where Node is installed and will remove the shims from there.
+
+### `corepack prepare [... name@version]`
 
 | Option | Description |
 | --- | --- |

--- a/sources/commands/Disable.ts
+++ b/sources/commands/Disable.ts
@@ -1,10 +1,10 @@
-import {Command, UsageError}                                   from 'clipanion';
-import fs                                                      from 'fs';
-import path                                                    from 'path';
-import which                                                   from 'which';
+import {Command, UsageError}                                             from 'clipanion';
+import fs                                                                from 'fs';
+import path                                                              from 'path';
+import which                                                             from 'which';
 
-import {Context}                                               from '../main';
-import {isSupportedPackageManager, SupportedPackageManagerSet} from '../types';
+import {Context}                                                         from '../main';
+import {isSupportedPackageManager, SupportedPackageManagerSetWithoutNpm} from '../types';
 
 export class DisableCommand extends Command<Context> {
   static usage = Command.Usage({
@@ -43,7 +43,7 @@ export class DisableCommand extends Command<Context> {
       installDirectory = path.dirname(await which(`corepack`));
 
     const names = this.names.length === 0
-      ? SupportedPackageManagerSet
+      ? SupportedPackageManagerSetWithoutNpm
       : this.names;
 
     for (const name of new Set(names)) {

--- a/sources/commands/Enable.ts
+++ b/sources/commands/Enable.ts
@@ -1,11 +1,11 @@
-import cmdShim                                                 from '@zkochan/cmd-shim';
-import {Command, UsageError}                                   from 'clipanion';
-import fs                                                      from 'fs';
-import path                                                    from 'path';
-import which                                                   from 'which';
+import cmdShim                                                           from '@zkochan/cmd-shim';
+import {Command, UsageError}                                             from 'clipanion';
+import fs                                                                from 'fs';
+import path                                                              from 'path';
+import which                                                             from 'which';
 
-import {Context}                                               from '../main';
-import {isSupportedPackageManager, SupportedPackageManagerSet} from '../types';
+import {Context}                                                         from '../main';
+import {isSupportedPackageManager, SupportedPackageManagerSetWithoutNpm} from '../types';
 
 export class EnableCommand extends Command<Context> {
   static usage = Command.Usage({
@@ -20,7 +20,7 @@ export class EnableCommand extends Command<Context> {
       `$0 enable`,
     ], [
       `Enable all shims, putting them in the specified directory`,
-      `$0 enable --bin-folder /path/to/folder`,
+      `$0 enable --install-directory /path/to/folder`,
     ], [
       `Enable the Yarn shim only`,
       `$0 enable yarn`,
@@ -51,7 +51,7 @@ export class EnableCommand extends Command<Context> {
       throw new Error(`Assertion failed: The stub folder doesn't exist`);
 
     const names = this.names.length === 0
-      ? SupportedPackageManagerSet
+      ? SupportedPackageManagerSetWithoutNpm
       : this.names;
 
     for (const name of new Set(names)) {

--- a/sources/types.ts
+++ b/sources/types.ts
@@ -11,6 +11,13 @@ export const SupportedPackageManagerSet = new Set<SupportedPackageManagers>(
   Object.values(SupportedPackageManagers),
 );
 
+export const SupportedPackageManagerSetWithoutNpm = new Set<SupportedPackageManagers>(
+  Object.values(SupportedPackageManagers),
+);
+
+// npm is distributed with Node as a builtin; we don't want Corepack to override it unless the npm team is on board
+SupportedPackageManagerSetWithoutNpm.delete(SupportedPackageManagers.Npm);
+
 export function isSupportedPackageManager(value: string): value is SupportedPackageManagers {
   return SupportedPackageManagerSet.has(value as SupportedPackageManagers);
 }

--- a/tests/Disable.test.ts
+++ b/tests/Disable.test.ts
@@ -1,11 +1,11 @@
-import {Filename, ppath, xfs, npath} from '@yarnpkg/fslib';
-import {delimiter}                   from 'path';
+import {Filename, ppath, xfs, npath}          from '@yarnpkg/fslib';
+import {delimiter}                            from 'path';
 
-import {Engine}                      from '../sources/Engine';
-import {SupportedPackageManagerSet}  from '../sources/types';
+import {Engine}                               from '../sources/Engine';
+import {SupportedPackageManagerSetWithoutNpm} from '../sources/types';
 
-import {makeBin, getBinaryNames}     from './_binHelpers';
-import {runCli}                      from './_runCli';
+import {makeBin, getBinaryNames}              from './_binHelpers';
+import {runCli}                               from './_runCli';
 
 const engine = new Engine();
 
@@ -19,7 +19,7 @@ describe(`DisableCommand`, () => {
       const corepackBin = await makeBin(cwd, `corepack` as Filename);
       const dontRemoveBin = await makeBin(cwd, `dont-remove` as Filename);
 
-      for (const packageManager of SupportedPackageManagerSet)
+      for (const packageManager of SupportedPackageManagerSetWithoutNpm)
         for (const binName of engine.getBinariesFor(packageManager))
           for (const variant of getBinaryNames(binName))
             await makeBin(cwd, variant as Filename, {ignorePlatform: true});
@@ -49,7 +49,7 @@ describe(`DisableCommand`, () => {
     await xfs.mktempPromise(async cwd => {
       const dontRemoveBin = await makeBin(cwd, `dont-remove` as Filename);
 
-      for (const packageManager of SupportedPackageManagerSet)
+      for (const packageManager of SupportedPackageManagerSetWithoutNpm)
         for (const binName of engine.getBinariesFor(packageManager))
           for (const variant of getBinaryNames(binName))
             await makeBin(cwd, variant as Filename, {ignorePlatform: true});
@@ -68,7 +68,7 @@ describe(`DisableCommand`, () => {
     await xfs.mktempPromise(async cwd => {
       const binNames = new Set<string>();
 
-      for (const packageManager of SupportedPackageManagerSet)
+      for (const packageManager of SupportedPackageManagerSetWithoutNpm)
         for (const binName of engine.getBinariesFor(packageManager))
           for (const variant of getBinaryNames(binName))
             binNames.add(variant);

--- a/tests/Enable.test.ts
+++ b/tests/Enable.test.ts
@@ -1,11 +1,11 @@
-import {Filename, ppath, xfs, npath}                          from '@yarnpkg/fslib';
-import {delimiter}                                            from 'path';
+import {Filename, ppath, xfs, npath}                                    from '@yarnpkg/fslib';
+import {delimiter}                                                      from 'path';
 
-import {Engine}                                               from '../sources/Engine';
-import {SupportedPackageManagerSet, SupportedPackageManagers} from '../sources/types';
+import {Engine}                                                         from '../sources/Engine';
+import {SupportedPackageManagers, SupportedPackageManagerSetWithoutNpm} from '../sources/types';
 
-import {makeBin, getBinaryNames}                              from './_binHelpers';
-import {runCli}                                               from './_runCli';
+import {makeBin, getBinaryNames}                                        from './_binHelpers';
+import {runCli}                                                         from './_runCli';
 
 const engine = new Engine();
 
@@ -33,7 +33,7 @@ describe(`EnableCommand`, () => {
       });
 
       const expectedEntries: Array<string> = [ppath.basename(corepackBin)];
-      for (const packageManager of SupportedPackageManagerSet)
+      for (const packageManager of SupportedPackageManagerSetWithoutNpm)
         for (const binName of engine.getBinariesFor(packageManager))
           expectedEntries.push(...getBinaryNames(binName));
 
@@ -54,7 +54,7 @@ describe(`EnableCommand`, () => {
       });
 
       const expectedEntries: Array<string> = [ppath.basename(corepackBin)];
-      for (const packageManager of SupportedPackageManagerSet)
+      for (const packageManager of SupportedPackageManagerSetWithoutNpm)
         for (const binName of engine.getBinariesFor(packageManager))
           expectedEntries.push(...getBinaryNames(binName));
 


### PR DESCRIPTION
The npm shim was accidentally being set when calling `corepack enable` with no parameters. Since my personal policy is to leave the npm team choose how they want to integrate with Corepack, let's disable this for now until they explicitly agree to have npm installed by Corepack as well.

For experimentation purposes I've left the ability to explicitly request the npm shim by running `corepack enable npm`.